### PR TITLE
Use F() to reduce RAM usage

### DIFF
--- a/examples/DumbModemLoraSender/DumbModemLoraSender.ino
+++ b/examples/DumbModemLoraSender/DumbModemLoraSender.ino
@@ -24,25 +24,25 @@ void setup() {
 
   modem.dumb();
 
-  Serial.println("LoRa Sender");
+  Serial.println(F("LoRa Sender"));
 
   // override the default CS, reset, and IRQ pins (optional)
   LoRa.setPins(LORA_IRQ_DUMB, 6, 1); // set CS, reset, IRQ pin
   LoRa.setSPIFrequency(100000);
 
   if (!LoRa.begin(SPI1, 915E6)) {
-    Serial.println("Starting LoRa failed!");
+    Serial.println(F("Starting LoRa failed!"));
     while (1);
   }
 }
 
 void loop() {
-  Serial.print("Sending packet: ");
+  Serial.print(F("Sending packet: "));
   Serial.println(counter);
 
   // send packet
   LoRa.beginPacket();
-  LoRa.print("hello ");
+  LoRa.print(F("hello "));
   LoRa.print(counter);
   LoRa.endPacket();
 

--- a/examples/FirstConfiguration/FirstConfiguration.ino
+++ b/examples/FirstConfiguration/FirstConfiguration.ino
@@ -21,32 +21,32 @@ void setup() {
   // put your setup code here, to run once:
   Serial.begin(115200);
   while (!Serial);
-  Serial.println("Welcome to MKRWAN1300 first configuration sketch");
-  Serial.println("Register to your favourite LoRa network and we are ready to go!");
+  Serial.println(F("Welcome to MKRWAN1300 first configuration sketch"));
+  Serial.println(F("Register to your favourite LoRa network and we are ready to go!"));
   // change this to your regional band (eg. US915, AS923, ...)
   if (!modem.begin(EU868)) {
-    Serial.println("Failed to start module");
+    Serial.println(F("Failed to start module"));
     while (1) {}
   };
-  Serial.print("Your module version is: ");
+  Serial.print(F("Your module version is: "));
   Serial.println(modem.version());
-  Serial.print("Your device EUI is: ");
+  Serial.print(F("Your device EUI is: "));
   Serial.println(modem.deviceEUI());
 
   int mode = 0;
   while (mode != 1 && mode != 2) {
-    Serial.println("Are you connecting via OTAA (1) or ABP (2)?");
+    Serial.println(F("Are you connecting via OTAA (1) or ABP (2)?"));
     while (!Serial.available());
     mode = Serial.readStringUntil('\n').toInt();
   }
 
   int connected;
   if (mode == 1) {
-    Serial.println("Enter your APP EUI");
+    Serial.println(F("Enter your APP EUI"));
     while (!Serial.available());
     appEui = Serial.readStringUntil('\n');
 
-    Serial.println("Enter your APP KEY");
+    Serial.println(F("Enter your APP KEY"));
     while (!Serial.available());
     appKey = Serial.readStringUntil('\n');
 
@@ -56,15 +56,15 @@ void setup() {
     connected = modem.joinOTAA(appEui, appKey);
   } else if (mode == 2) {
 
-    Serial.println("Enter your Device Address");
+    Serial.println(F("Enter your Device Address"));
     while (!Serial.available());
     devAddr = Serial.readStringUntil('\n');
 
-    Serial.println("Enter your NWS KEY");
+    Serial.println(F("Enter your NWS KEY"));
     while (!Serial.available());
     nwkSKey = Serial.readStringUntil('\n');
 
-    Serial.println("Enter your APP SKEY");
+    Serial.println(F("Enter your APP SKEY"));
     while (!Serial.available());
     appSKey = Serial.readStringUntil('\n');
 
@@ -76,7 +76,7 @@ void setup() {
   }
 
   if (!connected) {
-    Serial.println("Something went wrong; are you indoor? Move near a window and retry");
+    Serial.println(F("Something went wrong; are you indoor? Move near a window and retry"));
     while (1) {}
   }
 
@@ -88,9 +88,9 @@ void setup() {
   modem.print("HeLoRA world!");
   err = modem.endPacket(true);
   if (err > 0) {
-    Serial.println("Message sent correctly!");
+    Serial.println(F("Message sent correctly!"));
   } else {
-    Serial.println("Error sending message :(");
+    Serial.println(F("Error sending message :("));
   }
 }
 

--- a/examples/LoraSendAndReceive/LoraSendAndReceive.ino
+++ b/examples/LoraSendAndReceive/LoraSendAndReceive.ino
@@ -22,17 +22,17 @@ void setup() {
   while (!Serial);
   // change this to your regional band (eg. US915, AS923, ...)
   if (!modem.begin(EU868)) {
-    Serial.println("Failed to start module");
+    Serial.println(F("Failed to start module"));
     while (1) {}
   };
-  Serial.print("Your module version is: ");
+  Serial.print(F("Your module version is: "));
   Serial.println(modem.version());
-  Serial.print("Your device EUI is: ");
+  Serial.print(F("Your device EUI is: "));
   Serial.println(modem.deviceEUI());
 
   int connected = modem.joinOTAA(appEui, appKey);
   if (!connected) {
-    Serial.println("Something went wrong; are you indoor? Move near a window and retry");
+    Serial.println(F("Something went wrong; are you indoor? Move near a window and retry"));
     while (1) {}
   }
 
@@ -45,8 +45,8 @@ void setup() {
 
 void loop() {
   Serial.println();
-  Serial.println("Enter a message to send to network");
-  Serial.println("(make sure that end-of-line 'NL' is enabled)");
+  Serial.println(F("Enter a message to send to network"));
+  Serial.println(F("(make sure that end-of-line 'NL' is enabled)"));
 
   while (!Serial.available());
   String msg = Serial.readStringUntil('\n');
@@ -56,7 +56,7 @@ void loop() {
   for (unsigned int i = 0; i < msg.length(); i++) {
     Serial.print(msg[i] >> 4, HEX);
     Serial.print(msg[i] & 0xF, HEX);
-    Serial.print(" ");
+    Serial.print(F(" "));
   }
   Serial.println();
 
@@ -65,15 +65,15 @@ void loop() {
   modem.print(msg);
   err = modem.endPacket(true);
   if (err > 0) {
-    Serial.println("Message sent correctly!");
+    Serial.println(F("Message sent correctly!"));
   } else {
-    Serial.println("Error sending message :(");
-    Serial.println("(you may send a limited amount of messages per minute, depending on the signal strength");
-    Serial.println("it may vary from 1 message every couple of seconds to 1 message every minute)");
+    Serial.println(F("Error sending message :("));
+    Serial.println(F("(you may send a limited amount of messages per minute, depending on the signal strength"));
+    Serial.println(F("it may vary from 1 message every couple of seconds to 1 message every minute)"));
   }
   delay(1000);
   if (!modem.available()) {
-    Serial.println("No downlink message received at this time.");
+    Serial.println(F("No downlink message received at this time."));
     return;
   }
   String rcv;
@@ -85,7 +85,7 @@ void loop() {
   for (unsigned int i = 0; i < rcv.length(); i++) {
     Serial.print(rcv[i] >> 4, HEX);
     Serial.print(rcv[i] & 0xF, HEX);
-    Serial.print(" ");
+    Serial.print(F(" "));
   }
   Serial.println();
 }


### PR DESCRIPTION
Thank you for your great work on this library!

This PR simply adds `F()` when using `Serial.print()`, so as to move the text to the Flash memory instead of RAM.