### PR TITLE
Add getters for RX1 and RX2 windows

### DIFF
--- a/src/MKRWAN.h
+++ b/src/MKRWAN.h
@@ -618,6 +618,37 @@ public:
     return false;
   }
 
+  /**
+   * Returns the delay between the end of the Tx and the Rx Window 1 in ms.
+   * This may get changed automatically based on a network server's preference after joining it.
+   * This can be used to determine the wait time after a poll() call until data is available.
+   * Data will be available earliest after the RX1 window has passed.
+   * E.g. 
+   * modem.poll();
+   * delay(modem.getRX1Delay() + 1000);
+   * */
+  long getRX1Delay(){
+    sendAT(GF("+RX1DL?"));
+    if (waitResponse("+OK=") == 1) {
+        return stream.readStringUntil('\r').toInt();
+    }
+    return -1;
+  }
+
+  /**
+   * Returns the delay between the end of the Tx and the Rx Window 2 in ms.
+   * This may get changed automatically based on a network server's preference after joining it.
+   * This can be used to determine the wait time after a poll() call until data is available.
+   * @see getRX1Delay()
+   * */
+  long getRX2Delay(){
+    sendAT(GF("+RX2DL?"));
+    if (waitResponse() == 1) {
+        return stream.readStringUntil('\r').toInt();
+    }
+    return -1;
+  }
+
   String version() {
     sendAT(GF("+DEV?"));
     if (waitResponse("+OK=") == 1) {

--- a/src/MKRWAN.h
+++ b/src/MKRWAN.h
@@ -625,7 +625,9 @@ public:
    * Data will be available earliest after the RX1 window has passed.
    * E.g. 
    * modem.poll();
-   * delay(modem.getRX1Delay() + 1000);
+   * delay(modem.getRX1Delay() + 2000);
+   * Take into account the time required to demodulate the downlink message.
+   * At Spreading Factor 12 it can take more than two seconds while at SF7, it will take less than 100 ms.
    * */
   long getRX1Delay(){
     sendAT(GF("+RX1DL?"));


### PR DESCRIPTION
To minimize the wait time for downlink messages it's necessary to know the delay times of the RX1 and RX2 windows before any data can be available. After a call to `poll()` the device needs to wait at least until the RX1 window has passed. This PR implements the getter functions to do the math.
That way downlink messages can be retrieved reliably and with minimal wait time. E.g.

```cpp
modem.poll();
delay(modem.getRX1Delay() + 1000); // Allow for a bit of extra time for the transmission of the data
while (modem.available()) {   
  // Fetch data from the modem
}
```