### PR TITLE
Added #pragma once to fix errors caused by including the library twice

### DIFF
--- a/src/MKRWAN.h
+++ b/src/MKRWAN.h
@@ -19,6 +19,8 @@
   along with MKRWAN library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#pragma once
+
 #include "Arduino.h"
 
 #ifdef PORTENTA_CARRIER


### PR DESCRIPTION
A one line fix. Added `#pragma once` to the code to prevent problems when including the library twice or more. This happened to me when working on a more complex program with PlatformIO. 